### PR TITLE
Add audio/mpeg to approved mimetypes

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
     "audio/it",
     "audio/mid",
     "audio/mod",
+    "audio/mpeg",
     "audio/mpeg3",
     "audio/x-mpeg-3",
     "audio/mpeg3",


### PR DESCRIPTION
audio/mpeg is the RFC-defined mimetype for mp3, so should be here.